### PR TITLE
update CI: upgrade setup-bun to v2 and remove soldeer install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: "foundry-rs/foundry-toolchain@v1"
 
       - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
+        uses: "oven-sh/setup-bun@v2"
 
       - name: "Install the Node.js dependencies"
         run: "bun install"
@@ -45,13 +45,10 @@ jobs:
         uses: "foundry-rs/foundry-toolchain@v1"
 
       - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
+        uses: "oven-sh/setup-bun@v2"
 
       - name: "Install the Node.js dependencies"
         run: "bun install"
-
-      - name: "Install soldeer dependencies"
-        run: "forge soldeer install"
 
       - name: "Build the contracts and print their size"
         run: "forge build --sizes"
@@ -72,7 +69,7 @@ jobs:
         uses: "foundry-rs/foundry-toolchain@v1"
 
       - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
+        uses: "oven-sh/setup-bun@v2"
 
       - name: "Install the Node.js dependencies"
         run: "bun install"
@@ -85,9 +82,6 @@ jobs:
           echo "FOUNDRY_FUZZ_SEED=$(
             echo $(($EPOCHSECONDS - $EPOCHSECONDS % 604800))
           )" >> $GITHUB_ENV
-
-      - name: "Install soldeer dependencies"
-        run: "forge soldeer install"
 
       - name: "Run the tests"
         run: "forge test"


### PR DESCRIPTION
- oven-sh/setup-bun@v1 → @v2 to fix Node.js 20 deprecation warning
- Remove forge soldeer install steps (dependencies migrated to node_modules)